### PR TITLE
Change encoding in ant copy-task to UTF-8 to fix umlaut problems in h…

### DIFF
--- a/src/main/ant/build.xml
+++ b/src/main/ant/build.xml
@@ -48,7 +48,7 @@
             var text = self.getToken();
             if (text.startsWith('[[')) {
               var index = text.indexOf(']]');
-              self.setToken(text.substring(0, index).toLowerCase().replaceAll(' ','-') + text.substring(index));
+              self.setToken(text.substring(0, index).toLowerCase().replace(' ','-') + text.substring(index));
             }
           </scriptfilter>
         </tokenfilter>

--- a/src/main/ant/build.xml
+++ b/src/main/ant/build.xml
@@ -27,7 +27,7 @@
   </target>
   <target name="pre-process-asciidoc">
     <basename property="filename" file="${asciidoc-file}" suffix=".asciidoc"/>
-    <copy file="${asciidoc-file}" todir="${oasp.asciidoc.target}">
+    <copy file="${asciidoc-file}" todir="${oasp.asciidoc.target}" encoding="UTF-8">
       <filterchain>
         <tokenfilter>
           <linetokenizer/>

--- a/src/main/ant/build.xml
+++ b/src/main/ant/build.xml
@@ -48,7 +48,7 @@
             var text = self.getToken();
             if (text.startsWith('[[')) {
               var index = text.indexOf(']]');
-              self.setToken(text.substring(0, index).toLowerCase().replace(' ','-') + text.substring(index));
+              self.setToken(text.substring(0, index).toLowerCase().replaceAll(' ','-') + text.substring(index));
             }
           </scriptfilter>
         </tokenfilter>


### PR DESCRIPTION
This should fix problems with e.g. german umlaute in headings and multiple spaces in headings.